### PR TITLE
Added code-signing feature

### DIFF
--- a/src/ExtensibilityTools.cs
+++ b/src/ExtensibilityTools.cs
@@ -25,5 +25,7 @@ namespace MadsKristensen.ExtensibilityTools
     {
         
         public const int cmdAddCustomTool = 0x0001;
+        
+        public const int cmdSignBinary = 0x0002;
     }
 }

--- a/src/ExtensibilityTools.csproj
+++ b/src/ExtensibilityTools.csproj
@@ -170,6 +170,8 @@
       <SubType>Component</SubType>
     </Compile>
     <Compile Include="VSCT\Commands\AddCustomToolCommand.cs" />
+    <Compile Include="VSCT\Commands\BaseCommand.cs" />
+    <Compile Include="VSCT\Commands\SignBinaryCommand.cs" />
     <Compile Include="VSCT\Completion\VsctBuiltInCache.cs" />
     <Compile Include="VSCT\Completion\VsctCompletionController.cs" />
     <Compile Include="VSCT\Completion\VsctCompletionSet.cs" />

--- a/src/ExtensibilityTools.csproj
+++ b/src/ExtensibilityTools.csproj
@@ -180,9 +180,22 @@
     <Compile Include="VSCT\ContentType\VsctContentTypeDefinition.cs" />
     <Compile Include="VSCT\Generator\BaseCodeGenerator.cs" />
     <Compile Include="VSCT\Generator\VsctCodeGenerator.cs" />
+    <Compile Include="VSCT\Signing\CertificateHelper.cs" />
+    <Compile Include="VSCT\Signing\ComboBoxItem.cs" />
+    <Compile Include="VSCT\Signing\DialogHelper.cs" />
+    <Compile Include="VSCT\Signing\SignerHelper.cs" />
+    <Compile Include="VSCT\Signing\SignForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="VSCT\Signing\SignForm.Designer.cs">
+      <DependentUpon>SignForm.cs</DependentUpon>
+    </Compile>
     <Compile Include="VSCT\VsctTextViewCreationListener.cs" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="VSCT\Signing\SignForm.resx">
+      <DependentUpon>SignForm.cs</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="VSPackage.resx">
       <MergeWithCTO>true</MergeWithCTO>
       <ManifestResourceName>VSPackage</ManifestResourceName>

--- a/src/ExtensibilityTools.vsct
+++ b/src/ExtensibilityTools.vsct
@@ -14,6 +14,15 @@
                     <ButtonText>Auto-sync VSCT commands</ButtonText>
                 </Strings>
             </Button>
+
+            <Button guid="guidExtensibilityToolsCmdSet" id="cmdSignBinary" priority="0x0410" type="Button">
+                <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_PROJECT_BUILD"/>
+                <CommandFlag>DynamicVisibility</CommandFlag>
+                <CommandFlag>DefaultInvisible</CommandFlag>
+                <Strings>
+                    <ButtonText>Sign VSIX package...</ButtonText>
+                </Strings>
+            </Button>
         </Buttons>
     </Commands>
 
@@ -24,6 +33,7 @@
         <!-- This is the guid used to group the menu commands together -->
         <GuidSymbol name="guidExtensibilityToolsCmdSet" value="{5dbd2975-75e4-4f09-8b6d-1183b0c83762}">
             <IDSymbol name="cmdAddCustomTool" value="1" />
+            <IDSymbol name="cmdSignBinary" value="2" />
         </GuidSymbol>
     </Symbols>
 

--- a/src/ExtensibilityToolsPackage.cs
+++ b/src/ExtensibilityToolsPackage.cs
@@ -1,8 +1,6 @@
 ﻿using System.Runtime.InteropServices;
-using EnvDTE;
-using EnvDTE80;
 using MadsKristensen.ExtensibilityTools.Settings;
-using MadsKristensen.ExtensibilityTools.VSCT;
+using MadsKristensen.ExtensibilityTools.VSCT.Commands;
 using MadsKristensen.ExtensibilityTools.VSCT.Generator;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -28,6 +26,7 @@ namespace MadsKristensen.ExtensibilityTools
 
             Options = (Options)GetDialogPage(typeof(Options));
             AddCustomToolCommand.Initialize(this);
+            SignBinaryCommand.Initialize(this);
         }
     }
 }

--- a/src/VSCT/Commands/AddCustomToolCommand.cs
+++ b/src/VSCT/Commands/AddCustomToolCommand.cs
@@ -1,25 +1,19 @@
 ﻿using System;
-using System.ComponentModel.Design;
 using System.IO;
 using EnvDTE;
-using EnvDTE80;
+using MadsKristensen.ExtensibilityTools.VSCT.Generator;
 using Microsoft.VisualStudio.Shell;
 
-namespace MadsKristensen.ExtensibilityTools.VSCT
+namespace MadsKristensen.ExtensibilityTools.VSCT.Commands
 {
-    class AddCustomToolCommand
+    sealed class AddCustomToolCommand : BaseCommand
     {
-        private const string CUSTOM_TOOL_NAME = "VsctGenerator";
-        private IServiceProvider _provider;
-        private DTE2 _dte;
+        private const string CUSTOM_TOOL_NAME = VsctCodeGenerator.GeneratorName;
         private ProjectItem _item;
 
-        private AddCustomToolCommand(IServiceProvider provider)
+        private AddCustomToolCommand(IServiceProvider serviceProvider)
+            : base(serviceProvider)
         {
-            _provider = provider;
-            _dte = provider.GetService(typeof(DTE)) as DTE2;
-
-            SetupCommands();
         }
 
         public static AddCustomToolCommand Instance
@@ -33,21 +27,14 @@ namespace MadsKristensen.ExtensibilityTools.VSCT
             Instance = new AddCustomToolCommand(provider);
         }
 
-        private void SetupCommands()
+        protected override void SetupCommands()
         {
-            OleMenuCommandService commandService = _provider.GetService(typeof(IMenuCommandService)) as OleMenuCommandService;
-            if (commandService != null)
-            {
-                CommandID addCustomToolID = new CommandID(GuidList.guidExtensibilityToolsCmdSet, PackageCommands.cmdAddCustomTool);
-                OleMenuCommand addCustomToolItem = new OleMenuCommand(ShowMessageBox, addCustomToolID);
-                addCustomToolItem.BeforeQueryStatus += AddCustomToolItemBeforeQueryStatus;
-                commandService.AddCommand(addCustomToolItem);
-            }
+            AddCommand(GuidList.guidExtensibilityToolsCmdSet, PackageCommands.cmdAddCustomTool, ShowMessageBox, AddCustomToolItemBeforeQueryStatus);
         }
 
         private void AddCustomToolItemBeforeQueryStatus(object sender, EventArgs e)
         {
-            OleMenuCommand button = (OleMenuCommand)sender;
+            OleMenuCommand button = (OleMenuCommand) sender;
             button.Visible = false;
 
             UIHierarchyItem uiItem = GetSelectedItem();
@@ -56,6 +43,8 @@ namespace MadsKristensen.ExtensibilityTools.VSCT
                 return;
 
             _item = uiItem.Object as ProjectItem;
+            if (_item == null)
+                return;
 
             string fullPath = _item.Properties.Item("FullPath").Value.ToString();
             string ext = Path.GetExtension(fullPath);
@@ -65,18 +54,6 @@ namespace MadsKristensen.ExtensibilityTools.VSCT
 
             button.Checked = _item.Properties.Item("CustomTool").Value.ToString() == CUSTOM_TOOL_NAME;
             button.Visible = true;
-        }
-
-        private UIHierarchyItem GetSelectedItem()
-        {
-            var items = (Array)_dte.ToolWindows.SolutionExplorer.SelectedItems;
-
-            foreach (UIHierarchyItem selItem in items)
-            {
-                return selItem;
-            }
-
-            return null;
         }
 
         private void ShowMessageBox(object sender, EventArgs e)

--- a/src/VSCT/Commands/BaseCommand.cs
+++ b/src/VSCT/Commands/BaseCommand.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.ComponentModel.Design;
+using EnvDTE;
+using EnvDTE80;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace MadsKristensen.ExtensibilityTools.VSCT.Commands
+{
+    /// <summary>
+    /// Basic class to wrap code about executed menu command.
+    /// </summary>
+    abstract class BaseCommand
+    {
+        private readonly IServiceProvider _serviceProvider;
+        private readonly DTE2 _dte;
+
+        protected BaseCommand(IServiceProvider serviceProvider)
+        {
+            if (serviceProvider == null)
+                throw new ArgumentNullException("serviceProvider");
+
+            _serviceProvider = serviceProvider;
+            _dte = serviceProvider.GetService(typeof(SDTE)) as DTE2;
+
+            SetupCommands();
+        }
+
+        /// <summary>
+        /// Setups new menu command with handlers.
+        /// </summary>
+        protected OleMenuCommand AddCommand(Guid menuGroup, int commandID, EventHandler invokeHandler, EventHandler beforeQueryHandler)
+        {
+            if (invokeHandler == null)
+                throw new ArgumentNullException("invokeHandler", "Missing action to perform");
+
+            OleMenuCommandService commandService = GetService<OleMenuCommandService, IMenuCommandService>();
+            if (commandService != null)
+            {
+                OleMenuCommand addCustomToolItem = new OleMenuCommand(invokeHandler, new CommandID(menuGroup, commandID));
+
+                if (beforeQueryHandler != null)
+                {
+                    addCustomToolItem.BeforeQueryStatus += beforeQueryHandler;
+                }
+
+                commandService.AddCommand(addCustomToolItem);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Gets the currently selected solution item.
+        /// </summary>
+        protected UIHierarchyItem GetSelectedItem()
+        {
+            var items = (Array)_dte.ToolWindows.SolutionExplorer.SelectedItems;
+
+            foreach (UIHierarchyItem selItem in items)
+            {
+                return selItem;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Gets the specific service.
+        /// </summary>
+        protected T GetService<T, S>() where T : class
+        {
+            return _serviceProvider.GetService(typeof(S)) as T;
+        }
+
+        /// <summary>
+        /// Gets the specific service.
+        /// </summary>
+        protected T GetService<T>() where T : class
+        {
+            return _serviceProvider.GetService(typeof(T)) as T;
+        }
+
+        /// <summary>
+        /// Overriden by child class to setup own menu commands and bind with invocation handlers.
+        /// </summary>
+        protected abstract void SetupCommands();
+    }
+}

--- a/src/VSCT/Commands/SignBinaryCommand.cs
+++ b/src/VSCT/Commands/SignBinaryCommand.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using EnvDTE;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace MadsKristensen.ExtensibilityTools.VSCT.Commands
+{
+    sealed class SignBinaryCommand : BaseCommand
+    {
+        private const string ExtensibilityProjectGuid = "{82b43b9b-a64c-4715-b499-d71e9ca2bd60}";
+        private Project _project;
+
+        public SignBinaryCommand(IServiceProvider serviceProvider)
+            : base(serviceProvider)
+        {
+        }
+
+        public static SignBinaryCommand Instance
+        {
+            get;
+            private set;
+        }
+
+        public static void Initialize(IServiceProvider provider)
+        {
+            Instance = new SignBinaryCommand(provider);
+        }
+
+        /// <summary>
+        /// Overriden by child class to setup own menu commands and bind with invocation handlers.
+        /// </summary>
+        protected override void SetupCommands()
+        {
+            AddCommand(GuidList.guidExtensibilityToolsCmdSet, PackageCommands.cmdSignBinary, ShowSignBinaryUI, CheckForExtensibilityPackageFlavorBeforeQueryStatus);
+        }
+
+        private void ShowSignBinaryUI(object sender, EventArgs e)
+        {
+        }
+
+        private void CheckForExtensibilityPackageFlavorBeforeQueryStatus(object sender, EventArgs e)
+        {
+            OleMenuCommand button = (OleMenuCommand) sender;
+            button.Visible = false;
+
+            UIHierarchyItem uiItem = GetSelectedItem();
+
+            if (uiItem == null)
+                return;
+
+            _project = uiItem.Object as Project;
+            if (_project == null)
+                return;
+
+            var solution = GetService<IVsSolution>();
+            if (solution == null)
+                return;
+
+            IVsHierarchy projectHierarchy;
+            ErrorHandler.ThrowOnFailure(solution.GetProjectOfUniqueName(_project.UniqueName, out projectHierarchy));
+
+            var aggregatableProject = projectHierarchy as IVsAggregatableProject;
+            if (aggregatableProject == null)
+                return;
+
+            string projectTypeGuids;
+            ErrorHandler.ThrowOnFailure(aggregatableProject.GetAggregateProjectTypeGuids(out projectTypeGuids));
+
+            button.Visible = projectTypeGuids != null && projectTypeGuids.IndexOf(ExtensibilityProjectGuid, StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+    }
+}

--- a/src/VSCT/Commands/SignBinaryCommand.cs
+++ b/src/VSCT/Commands/SignBinaryCommand.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.IO;
 using EnvDTE;
+using MadsKristensen.ExtensibilityTools.VSCT.Signing;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -37,6 +39,8 @@ namespace MadsKristensen.ExtensibilityTools.VSCT.Commands
 
         private void ShowSignBinaryUI(object sender, EventArgs e)
         {
+            var form = new SignForm(GetPackagePath());
+            form.ShowDialog();
         }
 
         private void CheckForExtensibilityPackageFlavorBeforeQueryStatus(object sender, EventArgs e)
@@ -68,6 +72,23 @@ namespace MadsKristensen.ExtensibilityTools.VSCT.Commands
             ErrorHandler.ThrowOnFailure(aggregatableProject.GetAggregateProjectTypeGuids(out projectTypeGuids));
 
             button.Visible = projectTypeGuids != null && projectTypeGuids.IndexOf(ExtensibilityProjectGuid, StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+
+        private string GetPackagePath()
+        {
+            var activeConfiguration = _project.ConfigurationManager != null ? _project.ConfigurationManager.ActiveConfiguration : null;
+            if (activeConfiguration == null)
+                return null;
+
+            var properties = activeConfiguration.Properties;
+            var outputPath = properties.Item("OutputPath").Value.ToString();
+
+
+            properties = _project.Properties;
+            var projectFolder = properties.Item("FullPath").Value.ToString();
+            var assemblyName = properties.Item("AssemblyName").Value.ToString();
+
+            return Path.Combine(projectFolder, outputPath, assemblyName + ".vsix");
         }
     }
 }

--- a/src/VSCT/Signing/CertificateHelper.cs
+++ b/src/VSCT/Signing/CertificateHelper.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+using System.Security.Cryptography.X509Certificates;
+
+namespace MadsKristensen.ExtensibilityTools.VSCT.Signing
+{
+    /// <summary>
+    /// Helper class providing info about certificates.
+    /// This code comes from: https://github.com/phofman/signature
+    /// </summary>
+    static class CertificateHelper
+    {
+        /// <summary>
+        /// Loads all certificates that belong to current user.
+        /// </summary>
+        public static IEnumerable<X509Certificate2> LoadUserCertificates(string subjectName)
+        {
+            var certStore = new X509Store(StoreName.My, StoreLocation.CurrentUser);
+            try
+            {
+                certStore.Open(OpenFlags.ReadOnly);
+
+                var result = new List<X509Certificate2>();
+                var certificates = string.IsNullOrEmpty(subjectName) ? certStore.Certificates : certStore.Certificates.Find(X509FindType.FindBySubjectName, subjectName, true);
+                foreach (var cert in certificates)
+                {
+                    result.Add(cert);
+                }
+                return result;
+            }
+            finally
+            {
+                certStore.Close();
+            }
+        }
+
+        /// <summary>
+        /// Gets the list of timestamp servers.
+        /// </summary>
+        public static IEnumerable<string> LoadTimestampServers()
+        {
+            return new[] { "http://time.certum.pl", "http://timestamp.verisign.com/scripts/timstamp.dll", "http://timestamp.comodoca.com/authenticode" };
+        }
+    }
+}

--- a/src/VSCT/Signing/ComboBoxItem.cs
+++ b/src/VSCT/Signing/ComboBoxItem.cs
@@ -1,0 +1,40 @@
+﻿using System;
+
+namespace MadsKristensen.ExtensibilityTools.VSCT.Signing
+{
+    /// <summary>
+    /// Helper class to display items in combo-box.
+    /// This code comes from: https://github.com/phofman/signature
+    /// </summary>
+    sealed class ComboBoxItem
+    {
+        private readonly string _text;
+
+        /// <summary>
+        /// Init constructor.
+        /// </summary>
+        public ComboBoxItem(object data, string text)
+        {
+            if (string.IsNullOrEmpty(text))
+                throw new ArgumentNullException("text");
+
+            Data = data;
+            _text = text;
+        }
+
+        #region Properties
+
+        public object Data
+        {
+            get;
+            private set;
+        }
+
+        #endregion
+
+        public override string ToString()
+        {
+            return _text;
+        }
+    }
+}

--- a/src/VSCT/Signing/DialogHelper.cs
+++ b/src/VSCT/Signing/DialogHelper.cs
@@ -1,0 +1,76 @@
+﻿using System.IO;
+using System.Windows.Forms;
+
+namespace MadsKristensen.ExtensibilityTools.VSCT.Signing
+{
+    /// <summary>
+    /// Helper class to allow accessing files.
+    /// </summary>
+    static class DialogHelper
+    {
+        private static OpenFileDialog _openPackageDialog;
+        private static OpenFileDialog _openCertificateDialog;
+
+        /// <summary>
+        /// Creates dialog to point to binary file.
+        /// </summary>
+        public static OpenFileDialog OpenPackageFile(string title, string initPath)
+        {
+            if (_openPackageDialog != null)
+            {
+                _openPackageDialog.InitialDirectory = GetSecureInitPath(initPath);
+                return _openPackageDialog;
+            }
+
+            var openFile = new OpenFileDialog();
+            openFile.InitialDirectory = GetSecureInitPath(initPath);
+            openFile.Title = title;
+            openFile.DefaultExt = ".exe";
+            openFile.Filter = "VSIX Package|*.vsix;*.cab;*.msi|All files|*.*";
+
+            openFile.FilterIndex = 0;
+            openFile.CheckFileExists = true;
+            openFile.CheckPathExists = true;
+
+            return _openPackageDialog = openFile;
+        }
+        
+        /// <summary>
+        /// Creates dialog to point to certificate file.
+        /// </summary>
+        public static OpenFileDialog OpenCertificateFile(string title, string initPath)
+        {
+            if (_openCertificateDialog != null)
+            {
+                _openCertificateDialog.InitialDirectory = GetSecureInitPath(initPath);
+                return _openCertificateDialog;
+            }
+
+            var openFile = new OpenFileDialog();
+            openFile.InitialDirectory = GetSecureInitPath(initPath);
+            openFile.Title = title;
+            openFile.DefaultExt = ".pfx";
+            openFile.Filter = "Certificate File|*.pfx|All files|*.*";
+
+            openFile.FilterIndex = 0;
+            openFile.CheckFileExists = true;
+            openFile.CheckPathExists = true;
+
+            return _openCertificateDialog = openFile;
+        }
+
+        private static string GetSecureInitPath(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+                return null;
+
+            if (File.Exists(path))
+                return Path.GetDirectoryName(path);
+
+            if (Directory.Exists(path))
+                return path;
+
+            return null;
+        }
+    }
+}

--- a/src/VSCT/Signing/SignForm.Designer.cs
+++ b/src/VSCT/Signing/SignForm.Designer.cs
@@ -1,0 +1,270 @@
+﻿namespace MadsKristensen.ExtensibilityTools.VSCT.Signing
+{
+    partial class SignForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.label4 = new System.Windows.Forms.Label();
+            this.txtCertificatePassword = new System.Windows.Forms.TextBox();
+            this.txtCertificatePath = new System.Windows.Forms.TextBox();
+            this.label3 = new System.Windows.Forms.Label();
+            this.radioFromFile = new System.Windows.Forms.RadioButton();
+            this.cmbCertificates = new System.Windows.Forms.ComboBox();
+            this.txtSubjectFilter = new System.Windows.Forms.TextBox();
+            this.label2 = new System.Windows.Forms.Label();
+            this.radioInstalled = new System.Windows.Forms.RadioButton();
+            this.bttFindCertificate = new System.Windows.Forms.Button();
+            this.bttFindPackage = new System.Windows.Forms.Button();
+            this.txtPackagePath = new System.Windows.Forms.TextBox();
+            this.label1 = new System.Windows.Forms.Label();
+            this.bttCancel = new System.Windows.Forms.Button();
+            this.bttOK = new System.Windows.Forms.Button();
+            this.groupBox1.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // groupBox1
+            // 
+            this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.groupBox1.Controls.Add(this.label4);
+            this.groupBox1.Controls.Add(this.txtCertificatePassword);
+            this.groupBox1.Controls.Add(this.txtCertificatePath);
+            this.groupBox1.Controls.Add(this.label3);
+            this.groupBox1.Controls.Add(this.radioFromFile);
+            this.groupBox1.Controls.Add(this.cmbCertificates);
+            this.groupBox1.Controls.Add(this.txtSubjectFilter);
+            this.groupBox1.Controls.Add(this.label2);
+            this.groupBox1.Controls.Add(this.radioInstalled);
+            this.groupBox1.Controls.Add(this.bttFindCertificate);
+            this.groupBox1.Controls.Add(this.bttFindPackage);
+            this.groupBox1.Controls.Add(this.txtPackagePath);
+            this.groupBox1.Controls.Add(this.label1);
+            this.groupBox1.Location = new System.Drawing.Point(12, 12);
+            this.groupBox1.Name = "groupBox1";
+            this.groupBox1.Size = new System.Drawing.Size(847, 225);
+            this.groupBox1.TabIndex = 0;
+            this.groupBox1.TabStop = false;
+            this.groupBox1.Text = "Properties";
+            // 
+            // label4
+            // 
+            this.label4.AutoSize = true;
+            this.label4.Location = new System.Drawing.Point(185, 191);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(56, 13);
+            this.label4.TabIndex = 11;
+            this.label4.Text = "Password:";
+            // 
+            // txtCertificatePassword
+            // 
+            this.txtCertificatePassword.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtCertificatePassword.Location = new System.Drawing.Point(259, 188);
+            this.txtCertificatePassword.Name = "txtCertificatePassword";
+            this.txtCertificatePassword.Size = new System.Drawing.Size(527, 20);
+            this.txtCertificatePassword.TabIndex = 10;
+            // 
+            // txtCertificatePath
+            // 
+            this.txtCertificatePath.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtCertificatePath.Location = new System.Drawing.Point(259, 162);
+            this.txtCertificatePath.Name = "txtCertificatePath";
+            this.txtCertificatePath.Size = new System.Drawing.Size(527, 20);
+            this.txtCertificatePath.TabIndex = 9;
+            // 
+            // label3
+            // 
+            this.label3.AutoSize = true;
+            this.label3.Location = new System.Drawing.Point(185, 165);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(50, 13);
+            this.label3.TabIndex = 8;
+            this.label3.Text = "File path:";
+            // 
+            // radioFromFile
+            // 
+            this.radioFromFile.AutoSize = true;
+            this.radioFromFile.Location = new System.Drawing.Point(24, 163);
+            this.radioFromFile.Name = "radioFromFile";
+            this.radioFromFile.Size = new System.Drawing.Size(111, 17);
+            this.radioFromFile.TabIndex = 7;
+            this.radioFromFile.TabStop = true;
+            this.radioFromFile.Text = "Certificate from file";
+            this.radioFromFile.UseVisualStyleBackColor = true;
+            this.radioFromFile.CheckedChanged += new System.EventHandler(this.OnRadioCheckedChanged);
+            // 
+            // cmbCertificates
+            // 
+            this.cmbCertificates.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.cmbCertificates.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbCertificates.FormattingEnabled = true;
+            this.cmbCertificates.Location = new System.Drawing.Point(259, 102);
+            this.cmbCertificates.Name = "cmbCertificates";
+            this.cmbCertificates.Size = new System.Drawing.Size(527, 21);
+            this.cmbCertificates.TabIndex = 6;
+            // 
+            // txtSubjectFilter
+            // 
+            this.txtSubjectFilter.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtSubjectFilter.Location = new System.Drawing.Point(259, 76);
+            this.txtSubjectFilter.Name = "txtSubjectFilter";
+            this.txtSubjectFilter.Size = new System.Drawing.Size(527, 20);
+            this.txtSubjectFilter.TabIndex = 5;
+            this.txtSubjectFilter.TextChanged += new System.EventHandler(this.txtSubjectFilter_TextChanged);
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(185, 79);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(68, 13);
+            this.label2.TabIndex = 4;
+            this.label2.Text = "Subject filter:";
+            // 
+            // radioInstalled
+            // 
+            this.radioInstalled.AutoSize = true;
+            this.radioInstalled.Location = new System.Drawing.Point(24, 77);
+            this.radioInstalled.Name = "radioInstalled";
+            this.radioInstalled.Size = new System.Drawing.Size(113, 17);
+            this.radioInstalled.TabIndex = 3;
+            this.radioInstalled.TabStop = true;
+            this.radioInstalled.Text = "Installed certificate";
+            this.radioInstalled.UseVisualStyleBackColor = true;
+            this.radioInstalled.CheckedChanged += new System.EventHandler(this.OnRadioCheckedChanged);
+            // 
+            // bttFindCertificate
+            // 
+            this.bttFindCertificate.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.bttFindCertificate.Location = new System.Drawing.Point(792, 160);
+            this.bttFindCertificate.Name = "bttFindCertificate";
+            this.bttFindCertificate.Size = new System.Drawing.Size(49, 23);
+            this.bttFindCertificate.TabIndex = 2;
+            this.bttFindCertificate.Text = "...";
+            this.bttFindCertificate.UseVisualStyleBackColor = true;
+            this.bttFindCertificate.Click += new System.EventHandler(this.bttFindCertificate_Click);
+            // 
+            // bttFindPackage
+            // 
+            this.bttFindPackage.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.bttFindPackage.Location = new System.Drawing.Point(792, 26);
+            this.bttFindPackage.Name = "bttFindPackage";
+            this.bttFindPackage.Size = new System.Drawing.Size(49, 23);
+            this.bttFindPackage.TabIndex = 2;
+            this.bttFindPackage.Text = "...";
+            this.bttFindPackage.UseVisualStyleBackColor = true;
+            this.bttFindPackage.Click += new System.EventHandler(this.bttFindPackage_Click);
+            // 
+            // txtPackagePath
+            // 
+            this.txtPackagePath.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtPackagePath.Location = new System.Drawing.Point(153, 28);
+            this.txtPackagePath.Name = "txtPackagePath";
+            this.txtPackagePath.Size = new System.Drawing.Size(633, 20);
+            this.txtPackagePath.TabIndex = 1;
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(21, 31);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(77, 13);
+            this.label1.TabIndex = 0;
+            this.label1.Text = "Package path:";
+            // 
+            // bttCancel
+            // 
+            this.bttCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.bttCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.bttCancel.Location = new System.Drawing.Point(784, 243);
+            this.bttCancel.Name = "bttCancel";
+            this.bttCancel.Size = new System.Drawing.Size(75, 23);
+            this.bttCancel.TabIndex = 1;
+            this.bttCancel.Text = "&Cancel";
+            this.bttCancel.UseVisualStyleBackColor = true;
+            // 
+            // bttOK
+            // 
+            this.bttOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.bttOK.Location = new System.Drawing.Point(703, 243);
+            this.bttOK.Name = "bttOK";
+            this.bttOK.Size = new System.Drawing.Size(75, 23);
+            this.bttOK.TabIndex = 2;
+            this.bttOK.Text = "&OK";
+            this.bttOK.UseVisualStyleBackColor = true;
+            this.bttOK.Click += new System.EventHandler(this.bttOK_Click);
+            // 
+            // SignForm
+            // 
+            this.AcceptButton = this.bttOK;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.bttCancel;
+            this.ClientSize = new System.Drawing.Size(871, 278);
+            this.Controls.Add(this.bttOK);
+            this.Controls.Add(this.bttCancel);
+            this.Controls.Add(this.groupBox1);
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.MinimumSize = new System.Drawing.Size(340, 220);
+            this.Name = "SignForm";
+            this.ShowIcon = false;
+            this.ShowInTaskbar = false;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Signing VSIX package";
+            this.groupBox1.ResumeLayout(false);
+            this.groupBox1.PerformLayout();
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.GroupBox groupBox1;
+        private System.Windows.Forms.Button bttCancel;
+        private System.Windows.Forms.Button bttOK;
+        private System.Windows.Forms.Button bttFindPackage;
+        private System.Windows.Forms.TextBox txtPackagePath;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Label label4;
+        private System.Windows.Forms.TextBox txtCertificatePassword;
+        private System.Windows.Forms.TextBox txtCertificatePath;
+        private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.RadioButton radioFromFile;
+        private System.Windows.Forms.ComboBox cmbCertificates;
+        private System.Windows.Forms.TextBox txtSubjectFilter;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.RadioButton radioInstalled;
+        private System.Windows.Forms.Button bttFindCertificate;
+    }
+}

--- a/src/VSCT/Signing/SignForm.cs
+++ b/src/VSCT/Signing/SignForm.cs
@@ -1,0 +1,159 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Cryptography.X509Certificates;
+using System.Windows.Forms;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace MadsKristensen.ExtensibilityTools.VSCT.Signing
+{
+    public partial class SignForm : Form
+    {
+        public const string AppTitle = "Extensibility Tools";
+
+        public SignForm(string packagePath)
+        {
+            InitializeComponent();
+
+            radioInstalled.Checked = true;
+            txtSubjectFilter.Text = "Open Source Developer";
+            txtPackagePath.Text = packagePath;
+        }
+
+        private void FillCertificates(string subjectName)
+        {
+            cmbCertificates.Items.Clear();
+
+            IEnumerable<X509Certificate2> certificates = null;
+            try
+            {
+                certificates = CertificateHelper.LoadUserCertificates(subjectName);
+            }
+            catch (Exception ex)
+            {
+                cmbCertificates.Items.Add(new ComboBoxItem(null, ex.Message));
+            }
+
+
+            if (certificates != null)
+            {
+                foreach (var cert in certificates)
+                    cmbCertificates.Items.Add(new ComboBoxItem(cert, cert.SubjectName.Name));
+
+
+                if (cmbCertificates.Items.Count > 0)
+                {
+                    cmbCertificates.SelectedIndex = 0;
+                }
+            }
+        }
+
+        private void OnRadioCheckedChanged(object sender, EventArgs e)
+        {
+            bool enabled = radioInstalled.Checked;
+
+            txtSubjectFilter.Enabled = enabled;
+            cmbCertificates.Enabled = enabled;
+            txtCertificatePath.Enabled = !enabled;
+            txtCertificatePassword.Enabled = !enabled;
+            bttFindCertificate.Enabled = !enabled;
+
+
+            if (ActiveControl == radioInstalled || ActiveControl == radioFromFile)
+            {
+                if (enabled)
+                {
+                    ActiveControl = txtSubjectFilter;
+                }
+                else
+                {
+                    ActiveControl = txtCertificatePath;
+                }
+            } 
+            
+        }
+
+        private void txtSubjectFilter_TextChanged(object sender, EventArgs e)
+        {
+            FillCertificates(txtSubjectFilter.Text);
+        }
+
+        private void bttOK_Click(object sender, EventArgs e)
+        {
+            if (string.IsNullOrEmpty(txtPackagePath.Text) || !File.Exists(txtPackagePath.Text))
+            {
+                MessageBox.Show("You must specify path to existing VSIX package to sign", AppTitle, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                ActiveControl = txtPackagePath;
+                return;
+            }
+
+            if (txtCertificatePath.Enabled && (string.IsNullOrEmpty(txtCertificatePath.Text) || !File.Exists(txtCertificatePath.Text)))
+            {
+                MessageBox.Show("You must specify valid certificate PFX file", AppTitle, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                ActiveControl = txtCertificatePath;
+                return;
+            }
+
+            var certificate = cmbCertificates.SelectedItem != null ? ((ComboBoxItem)cmbCertificates.SelectedItem).Data as X509Certificate2 : null;
+            if (cmbCertificates.Enabled && certificate == null)
+            {
+                MessageBox.Show("You must select a valid certificate", AppTitle, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                ActiveControl = cmbCertificates;
+                return;
+            }
+
+            bool result;
+
+            if (cmbCertificates.Enabled)
+            {
+                result = SignerHelper.Sign(txtPackagePath.Text, certificate, null, null);
+            }
+            else
+            {
+                result = SignerHelper.Sign(txtPackagePath.Text, null, txtCertificatePath.Text, txtCertificatePassword.Text);
+            }
+
+            ShowMessageBox(result ? "The VSIX package has been digitally signed." : "There was an issue, while signing. Please try again.", AppTitle, result);
+            if (result)
+            {
+                Close();
+            }
+        }
+
+        private void ShowMessageBox(string content, string title, bool success)
+        {
+            var shell = Package.GetGlobalService(typeof(SVsUIShell)) as IVsUIShell;
+
+            if (shell != null)
+            {
+                Guid x = new Guid();
+                int result;
+
+                ErrorHandler.ThrowOnFailure(shell.ShowMessageBox(0, ref x, title, content, null, 0, OLEMSGBUTTON.OLEMSGBUTTON_OK, OLEMSGDEFBUTTON.OLEMSGDEFBUTTON_FIRST,
+                    success ? OLEMSGICON.OLEMSGICON_INFO : OLEMSGICON.OLEMSGICON_CRITICAL, 0, out result));
+            }
+        }
+
+        private void bttFindPackage_Click(object sender, EventArgs e)
+        {
+            var form = DialogHelper.OpenPackageFile("Searching for VSIX package", txtPackagePath.Text);
+
+            if (form.ShowDialog() == DialogResult.OK)
+            {
+                txtPackagePath.Text = form.FileName;
+            }
+        }
+
+        private void bttFindCertificate_Click(object sender, EventArgs e)
+        {
+            var form = DialogHelper.OpenCertificateFile("Searching for PFX certificate", txtCertificatePath.Text);
+
+            if (form.ShowDialog() == DialogResult.OK)
+            {
+                txtCertificatePath.Text = form.FileName;
+            }
+        }
+    }
+}

--- a/src/VSCT/Signing/SignForm.resx
+++ b/src/VSCT/Signing/SignForm.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/src/VSCT/Signing/SignerHelper.cs
+++ b/src/VSCT/Signing/SignerHelper.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Packaging;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace MadsKristensen.ExtensibilityTools.VSCT.Signing
+{
+    /// <summary>
+    /// Helper class performing some signing operations.
+    /// This code comes from: https://github.com/phofman/signature
+    /// </summary>
+    static class SignerHelper
+    {
+        /// <summary>
+        /// Signs the binary.
+        /// </summary>
+        public static bool Sign(string binaryPath, X509Certificate2 certificate, string certificatePath, string certificatePassword)
+        {
+            if (string.IsNullOrEmpty(binaryPath))
+                throw new ArgumentNullException("binaryPath");
+            if (certificate == null && string.IsNullOrEmpty(certificatePath))
+                throw new ArgumentException("certificate");
+
+            // is it a VSIX package?
+            var extension = Path.GetExtension(binaryPath);
+            if (string.Compare(extension, ".vsix", StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                if (certificate == null)
+                {
+                    try
+                    {
+                        certificate = new X509Certificate2(certificatePath, certificatePassword);
+                    }
+                    catch (Exception)
+                    {
+                        return false;
+                    }
+                }
+
+                return SignVsix(binaryPath, certificate);
+            }
+
+            return false;
+        }
+
+        private static bool SignVsix(string vsixPackagePath, X509Certificate2 certificate)
+        {
+            // many thanks to Jeff Wilcox for the idea and code
+            // check for details: http://www.jeff.wilcox.name/2010/03/vsixcodesigning/
+            using (var package = Package.Open(vsixPackagePath))
+            {
+                var signatureManager = new PackageDigitalSignatureManager(package);
+                signatureManager.CertificateOption = CertificateEmbeddingOption.InSignaturePart;
+
+                var partsToSign = new List<Uri>();
+                foreach (var packagePart in package.GetParts())
+                {
+                    partsToSign.Add(packagePart.Uri);
+                }
+
+                partsToSign.Add(PackUriHelper.GetRelationshipPartUri(signatureManager.SignatureOrigin));
+                partsToSign.Add(signatureManager.SignatureOrigin);
+                partsToSign.Add(PackUriHelper.GetRelationshipPartUri(new Uri("/", UriKind.RelativeOrAbsolute)));
+
+                try
+                {
+                    signatureManager.Sign(partsToSign, certificate);
+                }
+                catch (CryptographicException)
+                {
+                    return false;
+                }
+
+                return true;
+            }
+        }
+    }
+}


### PR DESCRIPTION
As in discussion in [#6](/madskristensen/ExtensibilityTools/issues/6) I implemented a code-signing feature. It's as simple as:

* right-click VSIX project

![menu](https://cloud.githubusercontent.com/assets/475630/7265079/6b41089c-e894-11e4-9da5-1709118bd230.jpg)

* click "Sign VSIX..."

* select certificate

![ui](https://cloud.githubusercontent.com/assets/475630/7265115/ce722144-e894-11e4-9ad9-0c65ade034da.jpg)

* click OK

All is done manually. No NuGet, no CI, not problems with exported passwords/certificates.
