### PR TITLE
Added option to execute build, when signing VSIX

### DIFF
--- a/src/VSCT/Commands/BaseCommand.cs
+++ b/src/VSCT/Commands/BaseCommand.cs
@@ -27,6 +27,14 @@ namespace MadsKristensen.ExtensibilityTools.VSCT.Commands
         }
 
         /// <summary>
+        /// Gets the IDE object wrapper.
+        /// </summary>
+        protected DTE2 DTE
+        {
+            get { return _dte; }
+        }
+
+        /// <summary>
         /// Setups new menu command with handlers.
         /// </summary>
         protected OleMenuCommand AddCommand(Guid menuGroup, int commandID, EventHandler invokeHandler, EventHandler beforeQueryHandler)

--- a/src/VSCT/Commands/SignBinaryCommand.cs
+++ b/src/VSCT/Commands/SignBinaryCommand.cs
@@ -39,8 +39,26 @@ namespace MadsKristensen.ExtensibilityTools.VSCT.Commands
 
         private void ShowSignBinaryUI(object sender, EventArgs e)
         {
-            var form = new SignForm(GetPackagePath());
+            var form = new SignForm(GetPackagePath(), BuildProjectToSign);
             form.ShowDialog();
+        }
+
+        private void BuildProjectToSign(object sender, EventArgs e)
+        {
+            Solution solution = DTE.Solution;
+            var selectedItem = GetSelectedItem();
+            Project project = selectedItem != null ? selectedItem.Object as Project : null;
+
+            // build the whole solution or only the selected project the command was invoked against:
+            if (project == null)
+            {
+                solution.SolutionBuild.Build(true);
+            }
+            else
+            {
+                // use the currently selected configuration and architecture:
+                solution.SolutionBuild.BuildProject(solution.SolutionBuild.ActiveConfiguration.Name, project.UniqueName, true);
+            }
         }
 
         private void CheckForExtensibilityPackageFlavorBeforeQueryStatus(object sender, EventArgs e)

--- a/src/VSCT/Signing/DialogHelper.cs
+++ b/src/VSCT/Signing/DialogHelper.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Diagnostics;
+using System.IO;
 using System.Windows.Forms;
 
 namespace MadsKristensen.ExtensibilityTools.VSCT.Signing
@@ -70,7 +71,23 @@ namespace MadsKristensen.ExtensibilityTools.VSCT.Signing
             if (Directory.Exists(path))
                 return path;
 
+            var parentPath = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(parentPath) && Directory.Exists(parentPath))
+                return parentPath;
+
             return null;
+        }
+
+        /// <summary>
+        /// Opens Windows Explorer window with specified file selected.
+        /// </summary>
+        public static void StartExplorerForFile(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+                return;
+
+            // open Explorer window with specified file selected:
+            Process.Start("Explorer.exe", "/select,\"" + path + "\"");
         }
     }
 }


### PR DESCRIPTION
Fixed issue madskristensen/ExtensibilityTools#10.
Additionally, when VSIX is signed correctly, it will open an explorer window and select the file.