### PR TITLE
Allow / Provide Bulk Export of Image Monikers

### DIFF
--- a/src/Misc/Commands/ImageMonikerDialog.xaml
+++ b/src/Misc/Commands/ImageMonikerDialog.xaml
@@ -1,4 +1,4 @@
-﻿<Window x:Class="MadsKristensen.ExtensibilityTools.Misc.Commands.ImageMonikerDialog"
+<Window x:Class="MadsKristensen.ExtensibilityTools.Misc.Commands.ImageMonikerDialog"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -56,10 +56,12 @@
                 <ColumnDefinition />
                 <ColumnDefinition Width="auto" />
                 <ColumnDefinition Width="auto" />
+                <ColumnDefinition Width="auto" />
             </Grid.ColumnDefinitions>
 
-            <Button x:Name="btnOk" Grid.Column="1" Content="Export..." Margin="0,0,10,0" HorizontalAlignment="Right" Width="75" Click="btnOk_Click"/>
-            <Button x:Name="btnCancel" Grid.Column="2" Content="Close" IsCancel="True" HorizontalAlignment="Right" VerticalAlignment="Bottom" Width="75"/>
+            <Button x:Name="btnOk" Grid.Column="1" Content="Export..." Margin="0,0,10,0" HorizontalAlignment="Right" Width="75" Click="btnOk_Click" ToolTip="Exports the currently selected Image Moniker"/>
+            <Button x:Name="btnExportAll" Grid.Column="2" Content="Export All" Margin="0,0,10,0" HorizontalAlignment="Right" Width="75" Click="btnExportAll_Click"  ToolTip="Exports all Image Monikers"/>
+            <Button x:Name="btnCancel" Grid.Column="3" Content="Close" IsCancel="True" HorizontalAlignment="Right" VerticalAlignment="Bottom" Width="75"/>
         </Grid>
 
     </Grid>


### PR DESCRIPTION
Hey there Mads,

I took the liberty to add a button & functionality to your Export Image Moniker window to allow bulk export of all Image Monikers for the entered size(s) to a chosen target directory.

I didn't want to change too much (i.e. add a progress bar while exporting) but it does the trick. Maybe you think its useful for others, too.

Cheers,
-Joerg