### PR TITLE
Making the "Show project information" menu item visible only on loaded projects

### DIFF
--- a/src/ExtensibilityTools.vsct
+++ b/src/ExtensibilityTools.vsct
@@ -57,6 +57,8 @@
                 <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_PROJECT_UNLOADRELOAD"/>
                 <Icon guid="ImageCatalogGuid" id="StatusInformationNoColor" />
                 <CommandFlag>IconIsMoniker</CommandFlag>
+                <CommandFlag>DynamicVisibility</CommandFlag>
+                <CommandFlag>DefaultInvisible</CommandFlag>
                 <Strings>
                     <ButtonText>Show Project Information</ButtonText>
                 </Strings>

--- a/src/Misc/Commands/ShowProjectInformation.cs
+++ b/src/Misc/Commands/ShowProjectInformation.cs
@@ -6,6 +6,7 @@ using EnvDTE;
 using System.Runtime.InteropServices;
 using System.Collections;
 using System.Collections.Generic;
+using Microsoft.VisualStudio.Shell;
 
 namespace MadsKristensen.ExtensibilityTools.VSCT.Commands
 {
@@ -34,7 +35,9 @@ namespace MadsKristensen.ExtensibilityTools.VSCT.Commands
 
         private void BeforeQueryStatus(object sender, EventArgs e)
         {
-            /* Nothing to do here */
+            Project project = ProjectHelpers.GetSelectedItem() as Project;
+
+            ((OleMenuCommand)sender).Visible = project != null;
         }
 
         private void ShowInformation(object sender, EventArgs e)


### PR DESCRIPTION
This fixes #26 