### PR TITLE
Support multiline descriptions

### DIFF
--- a/src/ExtensibilityTools.csproj
+++ b/src/ExtensibilityTools.csproj
@@ -154,15 +154,6 @@
       <Isolated>False</Isolated>
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </COMReference>
-    <COMReference Include="stdole">
-      <Guid>{00020430-0000-0000-C000-000000000046}</Guid>
-      <VersionMajor>2</VersionMajor>
-      <VersionMinor>0</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>primary</WrapperTool>
-      <Isolated>False</Isolated>
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </COMReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="EditorMargin\BottomMargin.cs" />

--- a/src/VsixManifest/Generator/ResxFileGenerator.cs
+++ b/src/VsixManifest/Generator/ResxFileGenerator.cs
@@ -110,7 +110,7 @@ namespace MadsKristensen.ExtensibilityTools.VsixManifest
             sb.AppendLine($"{indent(1)}{{");
             sb.AppendLine($"{indent(2)}public const string Id = \"{_manifest.ID}\";");
             sb.AppendLine($"{indent(2)}public const string Name = \"{_manifest.Name?.Replace("\\", "\\\\").Replace("\"", "\\\"")}\";");
-            sb.AppendLine($"{indent(2)}public const string Description = \"{_manifest.Description?.Replace("\\", "\\\\").Replace("\"", "\\\"")}\";");
+            sb.AppendLine($"{indent(2)}public const string Description = @\"{_manifest.Description}\";");
             sb.AppendLine($"{indent(2)}public const string Language = \"{_manifest.Language}\";");
             sb.AppendLine($"{indent(2)}public const string Version = \"{_manifest.Version}\";");
             sb.AppendLine($"{indent(2)}public const string Author = \"{_manifest.Author?.Replace("\\", "\\\\").Replace("\"", "\\\"")}\";");


### PR DESCRIPTION
Fixes #38 

I also had to remove the reference to stdole. On my machine (Win 10 Insider Slow + VS 2015 Update 3), it wasn't found. Running the extension in the debugger without this reference didn't seem to cause a problem, but if you prefer I can remove that change from the PR.