### PR TITLE
ImageManifest: Fix path to ManifestFromResources.exe

### DIFF
--- a/src/ImageManifest/Commands/AddImageManifestCommand.cs
+++ b/src/ImageManifest/Commands/AddImageManifestCommand.cs
@@ -124,7 +124,7 @@ namespace MadsKristensen.ExtensibilityTools
                     WorkingDirectory = Path.GetDirectoryName(fileName),
                     CreateNoWindow = true,
                     UseShellExecute = false,
-                    FileName = Path.Combine("c:\\users\\madsk", "ManifestFromResources.exe"),
+                    FileName = Path.Combine(toolsDir, "ManifestFromResources.exe"),
                     Arguments = args
                 };
 


### PR DESCRIPTION
Fix the path for invoking `ManifestFromResources.exe` to remove hard-coded user folder path and use assembly location path instead.