### PR TITLE
Dispose Classifier aggregators

### DIFF
--- a/src/EditorMargin/BottomMargin.cs
+++ b/src/EditorMargin/BottomMargin.cs
@@ -264,6 +264,8 @@ namespace MadsKristensen.ExtensibilityTools.EditorMargin
 
                 _doc.FileActionOccurred -= FileChangedOnDisk;
                 _textView.Caret.PositionChanged -= CaretPositionChanged;
+
+                (_classifier as IDisposable)?.Dispose();
             }
         }
     }

--- a/src/Pkgdef/Completion/PkgdefCompletionSource.cs
+++ b/src/Pkgdef/Completion/PkgdefCompletionSource.cs
@@ -263,7 +263,12 @@ namespace MadsKristensen.ExtensibilityTools.Pkgdef
 
         public void Dispose()
         {
-            _disposed = true;
+            if (!_disposed)
+            {
+                _disposed = true;
+
+                (_classifier as IDisposable)?.Dispose();
+            }
         }
     }
 }

--- a/src/Pkgdef/Validation/PkgdefErrorTagger.cs
+++ b/src/Pkgdef/Validation/PkgdefErrorTagger.cs
@@ -11,9 +11,10 @@ using Microsoft.VisualStudio.Text.Tagging;
 
 namespace MadsKristensen.ExtensibilityTools.Pkgdef
 {
-    class PkgdefErrorTagger : ITagger<IErrorTag>
+    class PkgdefErrorTagger : ITagger<IErrorTag>, IDisposable
     {
         private IClassifier _classifier;
+        private bool _disposed = false;
         private ErrorListProvider _errorlist;
         private ITextDocument _document;
         private IWpfTextView _view;
@@ -169,6 +170,16 @@ namespace MadsKristensen.ExtensibilityTools.Pkgdef
         {
             add { }
             remove { }
+        }
+
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                _disposed = true;
+
+                (_classifier as IDisposable)?.Dispose();
+            }
         }
     }
 

--- a/src/VSCT/Completion/VsctCompletionSource.cs
+++ b/src/VSCT/Completion/VsctCompletionSource.cs
@@ -267,7 +267,12 @@ namespace MadsKristensen.ExtensibilityTools.Vsct
 
         public void Dispose()
         {
-            _disposed = true;
+            if (!_disposed)
+            {
+                _disposed = true;
+
+                (_classifier as IDisposable)?.Dispose();
+            }
         }
     }
 }


### PR DESCRIPTION
Visual Studio disposes classifiers that it creates if they implement
IDisposable, even though it is undocumented. However the classifiers
created here by IClassifierAggregatorService.GetClassifier() were
not being disposed, so the underlying classifiers (from my own
extension) were not being disposed properly either.