### PR TITLE
fix CreateTagger throws if called before VsTextViewCreated

### DIFF
--- a/src/Pkgdef/Validation/PkgdefErrorTaggerProvider.cs
+++ b/src/Pkgdef/Validation/PkgdefErrorTaggerProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text;
@@ -24,12 +24,15 @@ namespace MadsKristensen.ExtensibilityTools.Pkgdef
         {
             if (!ExtensibilityToolsPackage.Options.PkgdefEnableValidation)
                 return null;
-
-            var errorlist = buffer.Properties.GetProperty(typeof(ErrorListProvider)) as ErrorListProvider;
-            var view = buffer.Properties.GetProperty(typeof(IWpfTextView)) as IWpfTextView;
+                
+            if (!buffer.Properties.TryGetProperty(typeof(ErrorListProvider), out ErrorListProvider errorlist))
+                return null;
+                
+            if (!buffer.Properties.TryGetProperty(typeof(IWpfTextView), out IWpfTextView view))
+                return null;
 
             ITextDocument document;
-            if (TextDocumentFactoryService.TryGetTextDocument(buffer, out document) && errorlist != null)
+            if (TextDocumentFactoryService.TryGetTextDocument(buffer, out document) && errorlist != null && view != null)
             {
                 return new PkgdefErrorTagger(view, _classifierAggregatorService, errorlist, document) as ITagger<T>;
             }


### PR DESCRIPTION
I just installed this extension and it was crashing because CreateTagger was getting called before PkgdefTextViewCreationListener.VsTextViewCreated from one of the extensions I had installed.